### PR TITLE
add js to hide fileds related to password change if user doesn't need…

### DIFF
--- a/app/assets/stylesheets/components/_login_form.scss
+++ b/app/assets/stylesheets/components/_login_form.scss
@@ -187,3 +187,27 @@ input[type="checkbox"]:focus,
     font-size: 1.2rem;
   }
 }
+
+.material-symbols-outlined {
+  font-variation-settings:
+  'FILL' 0,
+  'wght' 400,
+  'GRAD' 0,
+  'opsz' 48
+}
+
+.password-btn {
+  border: none;
+  background-color: white;
+  margin: 10px 0 20px;
+  font-size: 1rem !important;
+  color: var(--bs-body-color);
+
+  i {
+    margin-right: 7px;
+  }
+}
+
+.password-btn:hover {
+  text-decoration: underline;
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -22,6 +22,9 @@ application.register("hello", HelloController)
 import MapController from "./map_controller"
 application.register("map", MapController)
 
+import PasswordChangeController from "./password_change_controller"
+application.register("password-change", PasswordChangeController)
+
 import TomSelectController from "./tom_select_controller"
 application.register("tom-select", TomSelectController)
 

--- a/app/javascript/controllers/password_change_controller.js
+++ b/app/javascript/controllers/password_change_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="password-change"
+export default class extends Controller {
+  static targets = ["password"]
+
+  display(event) {
+    event.preventDefault();
+    this.passwordTarget.classList.toggle("d-none");
+  }
+}

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,27 +5,32 @@
         <div class="form-signup new-user">
           <h2 class="mt-5 mb-4 text-center">Edit my profile</h2>
 
-            <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+            <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: false }, html: { method: :put }) do |f| %>
               <%= f.error_notification %>
 
-              <div class="form-inputs">
+              <div class="form-inputs" data-controller="password-change">
                 <%= f.input :email, required: true, readonly: true, autofocus: true %>
 
                 <%# <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
                   <%# <p>Currently waiting confirmation for: <%= resource.unconfirmed_email</p> %>
                 <%# <% end %>
 
-                <%= f.input :password,
-                            hint: "Leave it blank if you don't want to change it.",
-                            required: false,
-                            input_html: { autocomplete: "new-password" } %>
-                <%= f.input :password_confirmation,
-                            required: false,
-                            input_html: { autocomplete: "new-password" } %>
-                <%= f.input :current_password,
-                            hint: "We need your current password to confirm your changes.",
-                            required: true,
-                            input_html: { autocomplete: "current-password" } %>
+
+                <button class="password-btn" data-action="click->password-change#display"><i class="fa-solid fa-key"></i>Change password</button>
+
+                <div class="password-change-fields d-none" data-password-change-target="password">
+                  <%= f.input :password,
+                              hint: "Leave it blank if you don't want to change it.",
+                              required: false,
+                              input_html: { autocomplete: "new-password" } %>
+                  <%= f.input :password_confirmation,
+                              required: false,
+                              input_html: { autocomplete: "new-password" } %>
+                  <%= f.input :current_password,
+                              hint: "We need your current password to confirm your changes.",
+                              required: true,
+                              input_html: { autocomplete: "current-password" } %>
+                </div>
                 <%= f.input :first_name,
                             required: true,
                             input_html: { autocomplete: "first name" } %>


### PR DESCRIPTION
Add js to hide fields related to password change if user doesn't need to change them 
Reason: form is too long – adding JS allows to reduce the form length by 3 fields.
<img width="505" alt="Screenshot 2022-11-20 at 22 53 46" src="https://user-images.githubusercontent.com/102035677/202931017-39c07baf-fa36-498e-b05a-e78e1aeef396.png">
<img width="503" alt="Screenshot 2022-11-20 at 22 53 59" src="https://user-images.githubusercontent.com/102035677/202931019-c675ea95-dc38-4f7b-b6ab-6dcdb09ce59c.png">
