### PR TITLE
fix filters on cities index, cities show and users index pages

### DIFF
--- a/app/assets/stylesheets/components/_inline_filters.scss
+++ b/app/assets/stylesheets/components/_inline_filters.scss
@@ -1,11 +1,12 @@
 // to be continued
 .filters {
   width: 100%;
-
-
+  display: flex;
+  flex-direction: column;
 
   form {
     width: 100%;
+    position: relative;
   }
 
   input {
@@ -17,19 +18,35 @@
     border: 1px solid #ced4da;
     border-radius: 0;
     border-left: none;
-    width: 16%;
+    width: 18%;
     padding: 0 8px;
   }
 
   .search {
-    width: 32%;
+    width: 45%;
     border-left: none;
   }
 
-  a {
-    display: inline-block;
-    width: 9%;
-    font-size: 0.9rem;
-    padding: 6px 8px;
+  .x-icon {
+    width: 10%;
+    color: $grey;
+    margin-left: 10px;
+    font-size: 16px;
+    font-weight: 300;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    position: absolute;
+    right: -140px;
+    text-decoration: none;
+
+    &:hover {
+      color: $pink-orange;
+    }
+
+    i {
+      margin-right: 5px;
+    }
   }
+
 }

--- a/app/assets/stylesheets/components/_map_filters.scss
+++ b/app/assets/stylesheets/components/_map_filters.scss
@@ -23,6 +23,23 @@
     margin-right: 13px;
   }
 
+  .filters-buttons {
+    display: flex;
+    align-items: center;
+
+    .btn-search {
+      // width: 50%;
+      margin-left: 25px;
+    }
+
+    .reset-text {
+      text-decoration: none;
+      color: white;
+      margin-left: 10px;
+      font-size: 15px;
+      font-weight: 300;
+    }
+  }
 }
 
 

--- a/app/assets/stylesheets/components/_user_card.scss
+++ b/app/assets/stylesheets/components/_user_card.scss
@@ -91,6 +91,13 @@
 
 .card-user .card-user-infos {
   padding: 16px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  .card-user-location {
+    margin-top: auto;
+  }
 
   i {
     color: $red;

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -11,8 +11,7 @@ class CitiesController < ApplicationController
     end
     @teammates = @teammates.filter_by_job(params[:job_title]) if params[:job_title].present?
     @teammates = @teammates.filter_by_department(params[:department]) if params[:department].present?
-    @teammates = @teammates.filter_by_languages(params[:languages]) if params[:languages].present?
-    @teammates = @teammates.to_a.select { |user| params[:date] == "" ? user.city.name == params[:city] : user.current_city(params[:date]).name == params[:city] } if params[:city].present?
+    # @teammates = @teammates.filter_by_languages(params[:languages]) if params[:languages].present?
 
     @cities = City.all
     @markers = @cities.geocoded.map do |city|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,8 +6,13 @@ class UsersController < ApplicationController
     @users = @users.search_by_job_city_name(params[:query]) if params[:query].present?
     @users = @users.filter_by_job(params[:job_title]) if params[:job_title].present?
     @users = @users.filter_by_department(params[:department]) if params[:department].present?
-    @users = @users.filter_by_open_to(params[:open_to]) if params[:open_to].present?
-    @users = @users.to_a.select { |user| params[:date] == "" ? user.city.name == params[:city] : user.current_city(params[:date]).name == params[:city] } if params[:city].present?
+    # @users = @users.filter_by_open_to(params[:open_to]) if params[:open_to].present?
+    @users = @users.to_a.select { |user| params[:date] == "" ? user.city.name.include?(params[:city]) : user.current_city(params[:date]).name.include?(params[:city])} if params[:city].present?
+
+    respond_to do |format|
+      format.html # Follow regular flow of Rails
+      format.text { render partial: 'users/list', :formats=>[:text, :html], locals: { users: @users } }
+    end
   end
 
   def show

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -31,6 +31,9 @@ application.register("map", MapController)
 import PasswordChangeController from "./password_change_controller"
 application.register("password-change", PasswordChangeController)
 
+import SearchPeopleController from "./search_people_controller"
+application.register("search-people", SearchPeopleController)
+
 import TomSelectController from "./tom_select_controller"
 application.register("tom-select", TomSelectController)
 

--- a/app/javascript/controllers/search_people_controller.js
+++ b/app/javascript/controllers/search_people_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="search-people"
+export default class extends Controller {
+  static targets = [ "form", "list", "searchInput", "selectCity", "selectDepartment", "selectDate" ]
+
+  refresh() {
+    const url = `${this.formTarget.action}?query=${this.searchInputTarget.value}&department=${this.selectDepartmentTarget.value}&city=${this.selectCityTarget.value}&date=${this.selectDateTarget.value}`;
+    fetch(url, { headers: { 'Accept': 'text/plain' } })
+    .then(response => response.text())
+    .then((data) => {
+      this.listTarget.outerHTML = data;
+    })
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,10 +7,11 @@ class User < ApplicationRecord
   serialize :open_to, Array
   include PgSearch::Model
   pg_search_scope :search_by_job_city_name,
-  against: [ :job_title, :first_name, :last_name, :city_id ],
+  against: [ :job_title, :first_name, :last_name, :department ],
   using: {
     tsearch: { prefix: true }
   }
+  # scope :filter_by_city, ->(city) { where("cities.name ILIKE ?", "#{city}%") }
   scope :filter_by_job, ->(job_title) { where job_title: job_title }
   scope :filter_by_department, ->(department) { where department: department }
   scope :filter_by_open_to, ->(open_to) { where("open_to ILIKE ?", "%#{open_to}%") }

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -7,16 +7,13 @@
       <summary class="mb-3">Filters</summary>
         <div class="input-div"><i class="fa-sharp fa-solid fa-user-tie"></i><%= f.select :job_title, User.all.collect { |u| [ u.job_title ] }.uniq, class: "custom-select", selected: params[:job_title], include_blank: "job title" %></div>
         <div class="input-div"><i class="fa-sharp fa-solid fa-briefcase"></i><%= f.select :department, User.all.collect { |u| [ u.department ] }.uniq, class: "custom-select", selected: params[:department], include_blank: "department" %></div>
-        <div class="input-div"><i class="fa-solid fa-door-open"></i>
+        <%# <div class="input-div"><i class="fa-solid fa-door-open"></i>
         <%= f.select :open_to, ["💻 Working together or side-by-side", "💡 Brainstorming", "🥐 Breakfast", "💬 Casual chat", "☕ Coffee", "🍻 Drinks", "🍲 Lunch & Dinner", "🤝 Networking at events", "🪂 Weekend Activity", "🏃 Sports"], class: "custom-select mb-3", selected: params[:open_to], include_blank: "open to" %>
-        </div>
-
-        <div class="row justify-content-center">
-          <%= link_to "Reset filters", cities_path, class: "btn btn-light" %>
-        </div>
+        <%# </div> %>
       </details>
-      <div class="row justify-content-center">
-        <%= f.submit "Search", class: "btn btn-light" %>
+      <div class="filters-buttons">
+        <%= f.submit "Search", class: "btn btn-pink btn-search" %>
+        <%= link_to "Clear", cities_path, class: "reset-text" %>
       </div>
     <% end %>
 </div>

--- a/app/views/cities/show.html.erb
+++ b/app/views/cities/show.html.erb
@@ -33,10 +33,11 @@
       <summary class="mb-3">Filters</summary>
       <div class="input-div"><i class="fa-sharp fa-solid fa-user-tie"></i><%= f.select :job_title, User.all.collect { |u| [ u.job_title ] }.uniq, class: "custom-select", selected: params[:job_title], include_blank: "job title" %></div>
       <div class="input-div"><i class="fa-sharp fa-solid fa-briefcase"></i><%= f.select :department, User.all.collect { |u| [ u.department ] }.uniq, class: "custom-select", selected: params[:department], include_blank: "department" %></div>
-      <div class="input-div"><i class="fa-solid fa-door-open"></i><%= f.select :open_to, ["💻 Working together or side-by-side", "💡 Brainstorming", "🥐 Breakfast", "💬 Casual chat", "☕ Coffee", "🍻 Drinks", "🍲 Lunch & Dinner", "🤝 Networking at events", "🪂 Weekend Activity", "🏃 Sports"], class: "custom-select mb-3", input_html: {multiple: true, data: {controller: "tom_select", tom_select_options_value: {tags: true}}}, selected: params[:open_to], include_blank: "open to" %></div>
+      <%# <div class="input-div"><i class="fa-solid fa-door-open"></i><%= f.select :open_to, ["💻 Working together or side-by-side", "💡 Brainstorming", "🥐 Breakfast", "💬 Casual chat", "☕ Coffee", "🍻 Drinks", "🍲 Lunch & Dinner", "🤝 Networking at events", "🪂 Weekend Activity", "🏃 Sports"], class: "custom-select mb-3", input_html: {multiple: true, data: {controller: "tom_select", tom_select_options_value: {tags: true}}}, selected: params[:open_to], include_blank: "open to" </div>%>
       </details>
-      <div class="row justify-content-center">
-      <%= f.submit "Search", class: "btn btn-light" %>
+      <div class="filters-buttons">
+        <%= f.submit "Search", class: "btn btn-pink btn-search" %>
+        <%= link_to "Clear", city_path(@city), class: "reset-text" %>
       </div>
     <% end %>
 </div>

--- a/app/views/users/_list.html.erb
+++ b/app/views/users/_list.html.erb
@@ -1,0 +1,26 @@
+<div class="row" data-search-people-target="list">
+    <% users.each do |user| %>
+      <div class="col-lg-3">
+        <div class="card-user">
+          <%= cl_image_tag user.photo.key %>
+          <div class="card-user-infos">
+            <h2 class="card-title">
+              <%= link_to(user_path(user)) do %>
+              <%= user.first_name %> <%= user.last_name %>
+              <% end %>
+            </h2>
+            <p><%= user.job_title %> (<%= user.department %>)</p>
+            <p class="card-user-location">
+              <% if params[:date].present? %>
+              <i class="fa-solid fa-map-pin"></i>
+                Will be in: <%= link_to user.current_city(params[:date]).name.split(",").first, city_path(user.current_city(params[:date])) %>
+              <% else %>
+              <i class="fa-solid fa-house-user"></i>
+                Based in: <%= link_to user.city.name.split(",").first, city_path(user.city) %>
+              <% end %>
+            </p>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -6,44 +6,21 @@
   <%# SEARCH AND FILTERS %>
 
 
-
-   <div class="filters mt-4">
-    <%= form_with url: users_path, method: :get, class: "d-flex mb-5" do |f| %>
-      <%= f.date_field :date, html5: true, value: params[:date], class: "form-control rounded-0" %>
-      <%= f.select :city, City.all.collect { |c| [ c.name.split(",").first ] }.sort, class: "custom-select", selected: params[:city], include_blank: "city" %>
-      <%= f.select :department, User.all.collect { |u| [ u.department ] }.uniq, class: "custom-select", selected: params[:department], include_blank: "department" %>
-      <%= text_field_tag :query, params[:query], class: "form-control search", placeholder: "Find colleagues by name or job title" %>
-      <%# <%= f.select :job_title, User.all.collect { |u| [ u.job_title ] }.uniq, class: "custom-select", selected: params[:job_title], include_blank: "job title" %>
-      <%= submit_tag "Search", class: "btn btn-dark rounded-0" %>
-      <%= link_to "Reset filters", users_path, class: "btn btn-light border border-dark rounded-0" %>
-    <% end %>
-  </div>
-
-  <%# CARDS %>
-  <div class="row">
-  <% @users.each do |user| %>
-    <div class="col-lg-3">
-      <div class="card-user">
-        <%= cl_image_tag user.photo.key %>
-        <div class="card-user-infos">
-          <h2 class="card-title">
-            <%= link_to(user_path(user)) do %>
-            <%= user.first_name %> <%= user.last_name %>
-            <% end %>
-          </h2>
-          <p><%= user.job_title %> (<%= user.department %>)</p>
-          <p>
-            <% if params[:date].present? %>
-            <i class="fa-solid fa-map-pin"></i>
-              Will be in: <%= link_to user.current_city(params[:date]).name.split(",").first, city_path(user.current_city(params[:date])) %>
-            <% else %>
-            <i class="fa-solid fa-house-user"></i>
-              Based in: <%= link_to user.city.name.split(",").first, city_path(user.city) %>
-            <% end %>
-          </p>
-        </div>
-      </div>
+  <div data-controller="search-people">
+    <div class="filters mt-4">
+      <%= form_with url: users_path, method: :get, html: { class: 'd-flex mb-5', data: { search_people_target: 'form' } } do |f| %>
+        <%= f.date_field :date, html5: true, value: params[:date], data: { search_people_target: 'selectDate', action: "change->search-people#refresh"}, class: "form-control rounded-0" %>
+        <%= f.select(:city, options_for_select(City.all.collect { |c| [ c.name.split(",").first ] }.sort, selected: params[:city]), {:include_blank => 'city'}, { class: 'custom-select', data: {search_people_target: 'selectCity', action: "change->search-people#refresh"} }) %>
+        <%= f.select(:department, options_for_select(User.all.collect { |u| [ u.department ] }.uniq, selected: params[:department]), {:include_blank => 'department'}, { class: 'custom-select', data: {search_people_target: 'selectDepartment', action: "change->search-people#refresh"} }) %>
+        <%= f.text_field :query, value: params[:query], data: { search_people_target: 'searchInput', action: "keyup->search-people#refresh"}, class: "form-control search", placeholder: "Find colleagues by name, job title or department" %>
+        <%= submit_tag "Search", class: "btn btn-dark rounded-0" %>
+        <%= link_to users_path, class: "x-icon" do %>
+          <i class="fa-solid fa-xmark"></i> Clear
+        <% end %>
+      <% end %>
     </div>
-  <% end %>
+
+    <%# CARDS %>
+    <%= render 'list', users: @users %>
   </div>
 </div>


### PR DESCRIPTION
Fixed filters on cities index, cities show and users index pages:
**User Index page:**
1. removed oped_to and languages filter
2. fixed city filter to display correct results
3. moved "Clear" button to the side
4. added AJAX requests to fetch results without submitting the form
<img width="1512" alt="Screenshot 2022-12-20 at 14 52 14" src="https://user-images.githubusercontent.com/102035677/208696813-6458d216-8366-4c4c-916f-88dd9a72ffb3.png">

**Cities Index and Cities Show page:**

1. Changed the styling of the button to our custom btn-pink class
2. Restyled the clear all button
<img width="326" alt="Screenshot 2022-12-20 at 14 52 29" src="https://user-images.githubusercontent.com/102035677/208696936-121d04f7-cd9e-4fe0-9129-4fe668b4e22c.png">
<img width="572" alt="Screenshot 2022-12-20 at 14 52 37" src="https://user-images.githubusercontent.com/102035677/208696941-a0dd117d-8183-4606-a99c-cd8f70e6941d.png">
