### PR TITLE
Restyle cities show

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -3,21 +3,19 @@
   background-color: #0c0c0c;
   background-size: contain;
   background-repeat: no-repeat;
-  background-position: left 70% 30%;
+  background-position: left 60% 30%;
   color:white;
-  width: 100%;
-  height: 80vh;
+  height: 88vh;
 }
 
 .homepage-text{
   padding-top: 10%;
   text-align: left;
-  margin-left: 65%;
+  margin-left: 55%;
   letter-spacing: 0.1rem;
 
   h1 {
-    font-size: 3rem;
-
+    font-size: 3.4rem;
   }
 
   p {

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -1,9 +1,10 @@
 .btn-map {
   position: absolute;
-  right: 2%;
-  top: 12%;
+  left: 2%;
+  bottom: 5%;
   z-index: 3;
   opacity: 0.6;
+  border-radius: 5px;
 }
 
 .btn-city-map {
@@ -90,4 +91,19 @@
 
 .modal-header {
   border-bottom-color: white !important;
+}
+
+.link {
+  text-decoration: none;
+  font-weight: 300;
+  color: lightgrey;
+  margin: 0;
+  padding: 0;
+  display: inline-block;
+  margin-left: 5px;
+
+  &:hover {
+    color: $pink-orange;
+  }
+
 }

--- a/app/assets/stylesheets/components/_cards_carousel.scss
+++ b/app/assets/stylesheets/components/_cards_carousel.scss
@@ -1,16 +1,31 @@
-#carouselCityUsers {
-  //max-height: fit-content;
-  position: absolute;
-  transform: translateX(25%);
-  bottom: 5%;
-  z-index: 2;
-  width: 65%;
-}
+// #carouselCityUsers {
+//   //max-height: fit-content;
+//   position: absolute;
+//   transform: translateX(25%);
+//   bottom: 5%;
+//   z-index: 2;
+//   width: 65%;
+// }
+
+// .cards-wrapper {
+//   display: flex;
+//   flex-direction: column;
+//   justify-content: center;
+//   width: 100%;
+// }
 
 .cards-wrapper {
-  display: flex;
-  justify-content: center;
-  width: 100%;
+    position: absolute;
+    top: 10%;
+    right: 2%;
+    display: flex;
+    flex-direction: column;
+    height: 85vh;
+    overflow-y: scroll;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
 }
 
 .card img {
@@ -19,11 +34,11 @@
 }
 
 .card {
-  margin: 0 0.5em;
+  margin: 0.5em 0.5em;
   box-shadow: 2px 6px 8px 0 rgba(22, 22, 26, 0.18);
   border: none;
   border-radius: 0;
-  width: 180px;
+  width: 200px;
   text-align: center;
   background-color: rgba(43, 41, 41, 0.8);
   border-radius: 7px;

--- a/app/assets/stylesheets/components/_cards_carousel.scss
+++ b/app/assets/stylesheets/components/_cards_carousel.scss
@@ -28,10 +28,6 @@
     }
 }
 
-.card img {
-  max-width: 100%;
-  max-height: 100%;
-}
 
 .card {
   margin: 0.5em 0.5em;
@@ -45,10 +41,24 @@
 }
 
 .card-body {
+  text-align: left;
+  padding: 16px 13px 16px 20px;
+
+  img {
+    width: 50px;
+    height: 62px;
+    border-radius: 4px;
+    object-fit: cover;
+  }
+
+  .card-body-info {
+    width: 62%;
+    margin-left: 10px;
+  }
 
   h6 {
-    padding-top: 3px;
     margin-bottom: 0px;
+
 
     a {
       color:white;
@@ -87,11 +97,15 @@
     font-weight: 300;
   }
 
-  i {
+  .fa-house-chimney {
     color: $pink-orange;
     position: absolute;
-    top: 12px;
-    right: 12px;
+    top: 8px;
+    left: 11px;
+  }
+
+  .fa-arrow-up-right-from-square {
+    font-size: 14px;
   }
 }
 

--- a/app/assets/stylesheets/components/_place_window.scss
+++ b/app/assets/stylesheets/components/_place_window.scss
@@ -1,5 +1,7 @@
 .city-map .mapboxgl-popup-content {
   width: 300px;
+  position: relative;
+  z-index: 10
 }
 
 
@@ -14,24 +16,24 @@
     justify-content: space-between;
     align-items: center;
 
-    .place-rating {
-      font-size: 16px;
-      margin-bottom: 0;
+  }
 
-      .fa-star {
-        color: rgb(255, 210, 15);
-      }
+  .place-rating {
+    font-size: 15px;
+    margin-bottom: 0;
 
-      .reviews-count {
-        font-size: 14px;
-        color: $gray;
-      }
+    .fa-star {
+      color: rgb(255, 210, 15);
+    }
+
+    .reviews-count {
+      font-size: 14px;
+      color: $gray;
     }
   }
 
   .reviews-container {
     padding-top: 10px;
-    margin-top: 15px;
     height: 200px;
     overflow-y: scroll;
   }
@@ -56,8 +58,7 @@
   .fa-map-location-dot {
     font-size: 1.15rem;
     color: $pink-orange;
-    margin-top: 5px;
-    margin-right: 10px;
+    margin-left: 10px;
     transition: 0.2s
   }
 
@@ -70,8 +71,6 @@
   .fa-heart {
     font-size: 1.15rem;
     color: $pink-orange;
-    margin-top: 5px;
-    margin-right: 10px;
     transition: 0.2s;
   }
 
@@ -99,10 +98,10 @@
 
 .tip-category {
   border: 1px solid $pink-orange;
+  background-color: #ffeceb;
   border-radius: 15px;
   display: inline-block;
   padding: 2px 15px;
   font-size: 0.7rem;
   font-weight: bold;
-  margin-bottom: 10px;
 }

--- a/app/assets/stylesheets/components/_place_window.scss
+++ b/app/assets/stylesheets/components/_place_window.scss
@@ -1,5 +1,5 @@
 .city-map .mapboxgl-popup-content {
-  width: 300px;
+  width: 320px;
   position: relative;
   z-index: 10
 }
@@ -21,6 +21,7 @@
   .place-rating {
     font-size: 15px;
     margin-bottom: 0;
+    margin-left: 5px;
 
     .fa-star {
       color: rgb(255, 210, 15);

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -11,7 +11,6 @@ class CitiesController < ApplicationController
     end
     @teammates = @teammates.filter_by_job(params[:job_title]) if params[:job_title].present?
     @teammates = @teammates.filter_by_department(params[:department]) if params[:department].present?
-    # @teammates = @teammates.filter_by_languages(params[:languages]) if params[:languages].present?
 
     @cities = City.all
     @markers = @cities.geocoded.map do |city|

--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -45,6 +45,9 @@ class CitiesController < ApplicationController
     @teammates = @teammates.filter_by_job(params[:job_title]) if params[:job_title].present?
     @teammates = @teammates.filter_by_department(params[:department]) if params[:department].present?
     @teammates = @teammates.filter_by_languages(params[:languages]) if params[:languages].present?
+
+    @teammates_city = @teammates.select { |t| t.current_city(@date) == @city }.compact
+
     @places = Place.where(city: @city)
     @tips = Tip.where(city: @city)
     @places_markers = @places.geocoded.map do |place|
@@ -54,11 +57,6 @@ class CitiesController < ApplicationController
         place_window: render_to_string(partial: "place_window", locals: { city: @city, place: place, tips: Tip.where(place: place) }),
         place_marker: render_to_string(partial: "place_marker", locals: { city: @city, places: @places, place: place, category: place.category })
       }
-    end
-    if params[:date]
-      @teammates_city = @teammates.select { |t| t.current_city(@date) == @city }.compact
-    else
-      @teammates_city = @teammates.select { |t| t.city == @city }.compact
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,10 +3,8 @@ class PagesController < ApplicationController
 
   def home
     @user = current_user
+    @teammates = User.where(company: current_user.company)
     @cities = City.all
-    @users = User.all
-    @trips = Trip.all
-    # @trips = City.all.trips
-    # @company_cities = current_user.company.users.city.count
+    @trips = Trip.joins(:user).where("users.company_id = ?", current_user.company.id)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,7 +23,7 @@ class UsersController < ApplicationController
     @slack = "slack://user?team=#{@company_domain}&id=#{@user_slack}"
     @linkedin = "https://www.linkedin.com/in/#{@user.linkedin}"
     @email = "mailto:#{@user.email}"
-    @trips = current_user.trips
+    @trips = @user.trips
     @upcoming_trips = @user.trips.select { |trip| trip.end_date > Date.today }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   using: {
     tsearch: { prefix: true }
   }
-  # scope :filter_by_city, ->(city) { where("cities.name ILIKE ?", "#{city}%") }
+
   scope :filter_by_job, ->(job_title) { where job_title: job_title }
   scope :filter_by_department, ->(department) { where department: department }
   scope :filter_by_open_to, ->(open_to) { where("open_to ILIKE ?", "%#{open_to}%") }

--- a/app/views/cities/_place_window.html.erb
+++ b/app/views/cities/_place_window.html.erb
@@ -1,31 +1,31 @@
 <div class="tip-window" data-controller="bookmarktip" data-user="<%= current_user.id %>">
-  <span class="tip-category"><%= place.category %></span>
-  <h4 class="tip-name"> <%= place.name %></h4>
-  <div class="place-details">
+  <div class="d-flex justify-content-between align-items-center mb-2">
+    <span class="tip-category"><%= place.category %></span>
     <p class="place-rating"><i class="fa-solid fa-star"></i> <%= place.tips.average(:rating).round(1) %>/10 (<span class="reviews-count"><%= place.tips.count %> reviews</span>)</p>
-    <div>
-      <%= link_to "https://www.google.com/maps/search/#{place.location}", target: :_blank do %>
-        <span title="See in Google Maps"><i class="fa-solid fa-map-location-dot"></i></span>
-      <% end %>
-
-      <% if current_user.bookmarked_place?(place) %>
-        <%= link_to  bookmarked_place_unfavourite_path(current_user.bookmarked_places.where(place_id: place.id).first), data: {bookmarktip_target: "unfav", action: 'click->bookmarktip#unfav'} do %>
-          <i class="fa-solid fa-heart"></i>
-        <% end %>
-        <%= link_to place_favourite_path(place), data: {bookmarktip_target: "fav", action: "click->bookmarktip#fav"}, class:"d-none" do %>
-          <i class="fa-regular fa-heart"></i>
-        <% end %>
-      <% else %>
-        <%= link_to  "/bookmarked_places/id/unfavourite", data: {bookmarktip_target: "unfav", action: 'click->bookmarktip#unfav'}, class:"d-none" do %>
-          <i class="fa-solid fa-heart"></i>
-        <% end %>
-        <%= link_to place_favourite_path(place), data: {bookmarktip_target: "fav", action: "click->bookmarktip#fav"} do %>
-          <i class="fa-regular fa-heart"></i>
-        <% end %>
-      <% end %>
-    </div>
   </div>
-  <div class="reviews-container">
+  <h4 class="tip-name">
+    <%= place.name %>
+    <%= link_to "https://www.google.com/maps/search/#{place.location}", target: :_blank do %>
+      <span title="See in Google Maps"><i class="fa-solid fa-map-location-dot"></i></span>
+    <% end %>
+
+    <% if current_user.bookmarked_place?(place) %>
+      <%= link_to  bookmarked_place_unfavourite_path(current_user.bookmarked_places.where(place_id: place.id).first), data: {bookmarktip_target: "unfav", action: 'click->bookmarktip#unfav'} do %>
+        <i class="fa-solid fa-heart"></i>
+      <% end %>
+      <%= link_to place_favourite_path(place), data: {bookmarktip_target: "fav", action: "click->bookmarktip#fav"}, class:"d-none" do %>
+        <i class="fa-regular fa-heart"></i>
+      <% end %>
+    <% else %>
+      <%= link_to  "/bookmarked_places/id/unfavourite", data: {bookmarktip_target: "unfav", action: 'click->bookmarktip#unfav'}, class:"d-none" do %>
+        <i class="fa-solid fa-heart"></i>
+      <% end %>
+      <%= link_to place_favourite_path(place), data: {bookmarktip_target: "fav", action: "click->bookmarktip#fav"} do %>
+        <i class="fa-regular fa-heart"></i>
+      <% end %>
+    <% end %>
+  </h4>
+  <div class="reviews-container mt-2">
     <% tips.each do |tip| %>
       <div class="review-container">
         <%= link_to user_path(tip.user.id), target: :_blank do %>

--- a/app/views/cities/show.html.erb
+++ b/app/views/cities/show.html.erb
@@ -43,16 +43,36 @@
 </div>
 <%= link_to "Back to World Map", cities_path, class: "btn btn-dark btn-map" %>
 
-<div class="city-map" style="width: 100%; height: 100vh;"
+<div class="city-map" style="width: 100%; height: 92vh;"
   data-controller="city"
   data-city-places-markers-value="<%= @places_markers.to_json %>"
   data-city-city-value="<%= @city.to_json %>"
   data-city-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>">
 </div>
 
+<div class="cards-wrapper">
+  <% @teammates_city.excluding(current_user).each do |t| %>
+    <div class="card">
+      <div class="card-body">
+        <% if t.city.name == @city.name %>
+          <span title="City local"><i class="fa-solid fa-house-chimney"></i></span>
+        <% end %>
+        <%= cl_image_tag t.photo.key, class: "avatar-small-carousel mb-2" %>
+        <h6 class="card-title">
+        <%= link_to(user_path(t)) do %>
+        <%= t.first_name %> <%= t.last_name %>
+        <% end %>
+        </h6>
+        <div class="d-flex justify-content-center align-items-center mt-2">
+          <p class="mb-0 mt-0 mr-3"><%= t.department  %> | </p>
+          <%= link_to "See profile", user_path(t), class: "link" %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>
 
-
-<div id="carouselCityUsers" class="carousel slide">
+<div id="carouselCityUsers" class="carousel slide d-none">
   <div class="carousel-inner">
     <% @teammates_city.excluding(current_user).each_with_index do |t, i| %>
       <% if i % 4 == 0 %>

--- a/app/views/cities/show.html.erb
+++ b/app/views/cities/show.html.erb
@@ -57,16 +57,30 @@
         <% if t.city.name == @city.name %>
           <span title="City local"><i class="fa-solid fa-house-chimney"></i></span>
         <% end %>
-        <%= cl_image_tag t.photo.key, class: "avatar-small-carousel mb-2" %>
-        <h6 class="card-title">
-        <%= link_to(user_path(t)) do %>
-        <%= t.first_name %> <%= t.last_name %>
-        <% end %>
-        </h6>
-        <div class="d-flex justify-content-center align-items-center mt-2">
-          <p class="mb-0 mt-0 mr-3"><%= t.department  %> | </p>
-          <%= link_to "See profile", user_path(t), class: "link" %>
+        <div class="d-flex">
+          <%= cl_image_tag t.photo.key, class: "" %>
+          <div class="card-body-info">
+            <h6>
+            <%= link_to(user_path(t)) do %>
+            <%= t.first_name %> <%= t.last_name %>
+            <% end %>
+            </h6>
+            <%# <div class="d-flex justify-content-center align-items-center mt-2"> %>
+            <p class="mb-0 mt-1 mr-3"><%= t.department  %></p>
+          </div>
         </div>
+        <% if t.trips.where("city_id = ?", @city.id).where("start_date <= ?", @date).where("end_date >= ?", @date).length > 0 %>
+          <p class="mb-0">Leaves on:
+          <strong><%= t.trips.where("city_id = ?", @city.id).where("start_date <= ?", @date).where("end_date >= ?", @date)[0].end_date.to_formatted_s(:short) %></strong>
+          </p>
+        <% elsif t.trips.where("city_id = ?", @city.id).where("start_date <= ?", @date).where("end_date >= ?", @date).empty? && t.trips.where("start_date >= ?", @date).length > 0  %>
+          <p class="mb-0">Leaves on:
+          <strong><%= t.trips.where("start_date >= ?", @date).first.start_date.to_formatted_s(:short) %></strong>
+          </p>
+        <% else %>
+          <p class="mb-0">No planned trips</p>
+        <% end %>
+        <%# </div> %>
       </div>
     </div>
   <% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -6,13 +6,9 @@
     <div class="container">
       <div class="homepage-text">
           <h1>Get the most from remote working</h1>
-          <p class="mb-2">Meet your coworkers from <%= current_user.company.name %> in <span data-controller="typed-js"></span> </h5>
-            <% num = 0 %>
-            <% @cities.each do |city| %>
-              <% num += city.trips.count%>
-            <% end %>
+          <p class="mb-2">Meet your coworkers from <%= current_user.company.name %> in <span data-controller="typed-js"></span>
           <div>
-            <p><span><%= @users.count %></span> teammates | <span><%= current_user.company.cities.uniq.count %></span> cities | <span><%= num %></span> upcoming trips  </p>
+            <p><span><%= @teammates.count %></span> teammates | <span><%= @cities.count %></span> cities | <span><%= @trips.count %></span> upcoming trips  </p>
           </div>
           <%= link_to "Explore", cities_path, class: "btn btn-dark btn-lg" %>
       </div>


### PR DESCRIPTION
Finished restyling the **cities show page**:
1. Moved the "Back to map" button to the bottom left corner
2. Replaced horizontal bootstrap carousel with a div with vertical scroll to leave more space for the map with places/tips
3. Restyled the person's card + added date when the person leaves this city (if he is on trip or if he is local, but going on a trip in future)
<img width="587" alt="Screenshot 2022-12-21 at 15 36 11" src="https://user-images.githubusercontent.com/102035677/208958663-e1722e5b-0339-469c-862e-d6b22e3ac491.png">
<img width="1512" alt="Screenshot 2022-12-21 at 16 43 39" src="https://user-images.githubusercontent.com/102035677/208959301-fdfa47a5-3204-4ee0-8f5b-7232e82f4a75.png">


4. Fixed the bug with calendar (it was previously showing only current user's trips and the person's whose profile you are checking)
5. Fixed the bug on the home page so that all counters work correctly and only display people/trips from your workspace
<img width="1512" alt="Screenshot 2022-12-21 at 16 34 03" src="https://user-images.githubusercontent.com/102035677/208959215-730b72c2-90e5-40f0-a95d-0f57a37d0d5d.png">
